### PR TITLE
Update codebase to python 3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,11 @@
+[bdist_wheel]
+universal = 1
+
+[flake8]
+max-complexity = 15
+max-line-length = 99
+docstring-convention = pep257
+# no docstrings in __init__.py
+# line breaks should be before binary operators
+ignore = D104,D107,W503
+exclude = venv

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name="python-regloicclib",
-      version="0.0.1",
+      version="0.1.0",
       description=("Library for driving the Ismatec Reglo ICC peristaltic pump."
                    "Communication is done over direct RS232 or through a serial server."),
       author="Alexander Bjoerling",

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python
+"""Python package setup."""
 from setuptools import setup
 
-setup(name = "python-regloicclib",
-      version = "0.0.1",
-      description = ("Library for driving the Ismatec Reglo ICC peristaltic pump."
-                     "Communication is done over direct RS232 or through a serial"
-                     "server."),
-      author = "Alexander Bjoerling",
-      author_email = "alexander.bjorling@maxiv.lu.se",
-      license = "GPLv3",
-      url = "http://www.maxiv.lu.se",
-      packages =['regloicclib'],
-      package_dir = {'':'src'},
-     )
+setup(name="python-regloicclib",
+      version="0.0.1",
+      description=("Library for driving the Ismatec Reglo ICC peristaltic pump."
+                   "Communication is done over direct RS232 or through a serial server."),
+      author="Alexander Bjoerling",
+      author_email="alexander.bjorling@maxiv.lu.se",
+      license="GPLv3",
+      url="http://www.maxiv.lu.se",
+      packages=['regloicclib'],
+      package_dir={'': 'src'},
+      )

--- a/setup.py
+++ b/setup.py
@@ -12,4 +12,16 @@ setup(name="python-regloicclib",
       url="http://www.maxiv.lu.se",
       packages=['regloicclib'],
       package_dir={'': 'src'},
+      install_requires=[
+          'pyserial',
+      ],
+      classifiers=[
+          "Development Status :: 4 - Beta",
+          'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+          "Natural Language :: English",
+          "Programming Language :: Python",
+          "Programming Language :: Python :: 3",
+          "Topic :: Scientific/Engineering :: Human Machine Interfaces",
+          "Topic :: Scientific/Engineering :: Chemistry"
+      ]
       )

--- a/src/regloicclib/Pump.py
+++ b/src/regloicclib/Pump.py
@@ -38,7 +38,10 @@ class Pump(object):
         self.hw.write(b'1~1')
 
         # Get number of channels
-        nChannels = int(self.hw.query(b'1xA'))
+        try:
+            nChannels = int(self.hw.query(b'1xA'))
+        except ValueError:
+            nChannels = 0
 
         # Enable asynchronous messages
         self.hw.write(b'1xE1')

--- a/src/regloicclib/Pump.py
+++ b/src/regloicclib/Pump.py
@@ -1,6 +1,6 @@
 import time
 import serial
-from Communicator import SerialCommunicator, SocketCommunicator
+from .Communicator import SerialCommunicator, SocketCommunicator
 
 class Pump(object):
     """
@@ -28,22 +28,22 @@ class Pump(object):
         self.hw.start()
 
         # Assign address 1 to pump
-        self.hw.write('@1')
+        self.hw.write(b'@1')
 
         # Set everything to default
-        self.hw.write('10')
+        self.hw.write(b'10')
 
         # Enable independent channel addressing
-        self.hw.write('1~1')
+        self.hw.write(b'1~1')
 
         # Get number of channels
-        nChannels = int(self.hw.query('1xA'))
+        nChannels = int(self.hw.query(b'1xA'))
 
         # Enable asynchronous messages
-        self.hw.write('1xE1')
+        self.hw.write(b'1xE1')
 
         # list of channel indices for iteration and checking
-        self.channels = range(1, nChannels+1)
+        self.channels = list(range(1, nChannels+1))
 
         # initial running states
         self.stop()
@@ -55,10 +55,10 @@ class Pump(object):
     ####################################################################
 
     def getPumpVersion(self):
-        return self.hw.query('1#').strip()
+        return self.hw.query(b'1#').strip()
 
     def getRunning(self, channel):
-        """ 
+        """
         Returns True if the specified channels is running
         """
         assert channel in self.channels
@@ -66,15 +66,15 @@ class Pump(object):
 
     def getTubingInnerDiameter(self, channel):
         """ 
-        Returns the set inner diameter of the peristaltic tubing on the 
+        Returns the set inner diameter of the peristaltic tubing on the
         specified channel, in mm.
         """
         assert channel in self.channels
-        return float(self.hw.query('%d+'%channel).split(' ')[0])
+        return float(self.hw.query(b'%d+'%channel).split(' ')[0])
 
     def setTubingInnerDiameter(self, diam, channel=None):
         """
-        Sets the inner diameter of the peristaltic tubing on the 
+        Sets the inner diameter of the peristaltic tubing on the
         specified channel or on all channels.
         """
         if channel is None:
@@ -82,15 +82,15 @@ class Pump(object):
             for ch in self.channels:
                 allgood = allgood and self.setTubingInnerDiameter(diam, channel=ch)
             return allgood
-        return self.hw.write('%d+%s'%(channel, self._discrete2(diam)))
+        return self.hw.write(b'%d+%s'%(channel, self._discrete2(diam).encode()))
 
     ###########################################
     # Methods to be exposed as Tango commands #
     ###########################################
 
-    def continuousFlow(self, rate, channel=None): 
-        """ 
-        Start continuous flow at rate (ml/min) on specified channel or 
+    def continuousFlow(self, rate, channel=None):
+        """
+        Start continuous flow at rate (ml/min) on specified channel or
         on all channels.
         """
         if channel is None:
@@ -98,29 +98,29 @@ class Pump(object):
             channel = 0
             maxrates = []
             for ch in self.channels:
-                maxrates.append(float(self.hw.query('%d?'%ch).split(' ')[0]))
+                maxrates.append(float(self.hw.query(b'%d?'%ch).split(' ')[0]))
             maxrate = min(maxrates)
         else:
-            maxrate = float(self.hw.query('%d?'%channel).split(' ')[0])
+            maxrate = float(self.hw.query(b'%d?'%channel).split(' ')[0])
         assert channel in self.channels or channel == 0
         # flow rate mode
-        self.hw.write('%dM'%channel)
+        self.hw.write(b'%dM'%channel)
         # set flow direction
         if rate < 0:
-            self.hw.write('%dK'%channel)
+            self.hw.write(b'%dK'%channel)
         else:
-            self.hw.write('%dJ'%channel)
+            self.hw.write(b'%dJ'%channel)
         # set flow rate
         if abs(rate) > maxrate:
             rate = rate / abs(rate) * maxrate
-        self.hw.query('%df%s'%(channel, self._volume2(rate)))
+        self.hw.query(b'%df%s'%(channel, self._volume2(rate).encode()))
         # make sure the running status gets set from the start to avoid later Sardana troubles
         self.hw.setRunningStatus(True, channel)
         # start
-        self.hw.write('%dH'%channel)
+        self.hw.write(b'%dH'%channel)
 
     def dispense(self, vol, rate, channel=None):
-        """ 
+        """
         Dispense vol (ml) at rate (ml/min) on specified channel or on
         all channels.
         """
@@ -129,36 +129,36 @@ class Pump(object):
             channel = 0
             maxrates = []
             for ch in self.channels:
-                maxrates.append(float(self.hw.query('%d?'%ch).split(' ')[0]))
+                maxrates.append(float(self.hw.query(b'%d?'%ch).split(' ')[0]))
             maxrate = min(maxrates)
         else:
-            maxrate = float(self.hw.query('%d?'%channel).split(' ')[0])
+            maxrate = float(self.hw.query(b'%d?'%channel).split(' ')[0])
         assert channel in self.channels or channel == 0
         # flow rate mode
-        self.hw.write('%dO'%channel)
+        self.hw.write(b'%dO'%channel)
         # make volume positive
         if vol < 0:
             vol *= -1
             rate *= -1
         # set flow direction
         if rate < 0:
-            self.hw.write('%dK'%channel)
+            self.hw.write(b'%dK'%channel)
         else:
-            self.hw.write('%dJ'%channel)
+            self.hw.write(b'%dJ'%channel)
         # set flow rate
         if abs(rate) > maxrate:
             rate = rate / abs(rate) * maxrate
-        self.hw.query('%df%s'%(channel, self._volume2(rate)))
+        self.hw.query(b'%df%s'%(channel, self._volume2(rate).encode()))
         # set volume
-        self.hw.query('%dv%s'%(channel, self._volume2(vol)))
+        self.hw.query(b'%dv%s'%(channel, self._volume2(vol).encode()))
         # make sure the running status gets set from the start to avoid later Sardana troubles
         self.hw.setRunningStatus(True, channel)
         # start
-        self.hw.write('%dH'%channel)
+        self.hw.write(b'%dH'%channel)
 
     def stop(self, channel=None):
         """
-        Stop any pumping operation on specified channel or on all 
+        Stop any pumping operation on specified channel or on all
         channels.
         """
         # here we can stop all channels by specifying 0
@@ -166,7 +166,7 @@ class Pump(object):
         assert channel in self.channels or channel == 0
         # doing this misses the asynchronous stop signal, so set manually
         self.hw.setRunningStatus(False, channel)
-        return self.hw.write('%dI'%channel)
+        return self.hw.write(b'%dI'%channel)
 
     ##########################################
     # Helper methods, not for Tango exposure #
@@ -202,7 +202,7 @@ def example_usage():
     p.dispense(vol=1, rate=25, channel=2)
     t0 = time.time()
     while time.time() - t0 < 10:
-        print [p.getRunning(channel=i) for i in p.channels]
+        print([p.getRunning(channel=i) for i in p.channels])
         time.sleep(.5)
     p.stop()
-    print [p.getRunning(channel=i) for i in p.channels]
+    print([p.getRunning(channel=i) for i in p.channels])

--- a/src/regloicclib/__init__.py
+++ b/src/regloicclib/__init__.py
@@ -1,2 +1,2 @@
-from Pump import *
-from Communicator import *
+from .Pump import *
+from .Communicator import *

--- a/src/regloicclib/__init__.py
+++ b/src/regloicclib/__init__.py
@@ -1,2 +1,2 @@
-from .Pump import *
-from .Communicator import *
+from .Pump import Pump
+from .Communicator import SerialCommunicator, SocketCommunicator


### PR DESCRIPTION
- Update from python2 to python3.  The biggest change involves strings.  `encode()`/`decode()` must be used to switch between bytes for serial and Unicode.  If you still want Python2 support, we can add it back in with the `future` module.  If not, I'd go full Python3 with f-strings, [abstract methods](https://stackoverflow.com/a/13646263), and `asyncio` instead of threading.
- Lint everything according to PEP8. (I'm using `flake8` and changed line lengths to 99)
- Flesh out docstrings and `setup.py`.
- Combine the command and query queues, and rename them requests to match the documentation.  Extending `readline()` to read `*` makes the same code works for commands and queries.  Note:  If a command fails (e.g. returns `-`) it will depend on the timeout, for now.

Happy to break this up if you don't want all the changes, or resubmit later since I'm still refactoring.  I was able to successfully use `getFlowrate()`, `getPumpVersion()`, `continuousFlow()`, `dispense()`, and `stop()` with a serial gateway only.  Eventually I'd like to get this submitted to PyPI.