### PR TITLE
Distinguish multiple dispense methods - vol at rate and vol over time

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name="python-regloicclib",
-      version="0.1.0",
+      version="0.2.0",
       description=("Library for driving the Ismatec Reglo ICC peristaltic pump."
                    "Communication is done over direct RS232 or through a serial server."),
       author="Alexander Bjoerling",

--- a/src/regloicclib/Communicator.py
+++ b/src/regloicclib/Communicator.py
@@ -55,7 +55,7 @@ class Communicator(threading.Thread):
             self.running[channel] = status
 
     def run(self):
-        """Run continously until threading.Event fires."""
+        """Run continuously until threading.Event fires."""
         while not self._stop_event.isSet():
             self.loop()
         self.close()

--- a/src/regloicclib/Pump.py
+++ b/src/regloicclib/Pump.py
@@ -82,7 +82,7 @@ class Pump(object):
         """
         Set the peristaltic tubing inner diameter on the specified channel, in mm.
 
-        If no channel is specificed, set it on all channels.
+        If no channel is specified, set it on all channels.
         """
         if channel is None:
             allgood = True


### PR DESCRIPTION
Hello Alex,

I've dusted off this project again and found it useful to split `dispense` into two methods.  If needed to keep backwards compatibility, I could refactor to keep `dispense` the same and add `dispense_at_rate` as an alias to it.


Do you have any interest in publishing to PyPI?