### PR TITLE
Add method to dispense at a set flowrate over time

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name="python-regloicclib",
-      version="0.2.0",
+      version="0.3.0",
       description=("Library for driving the Ismatec Reglo ICC peristaltic pump."
                    "Communication is done over direct RS232 or through a serial server."),
       author="Alexander Bjoerling",

--- a/src/regloicclib/Communicator.py
+++ b/src/regloicclib/Communicator.py
@@ -174,7 +174,6 @@ class SocketCommunicator(Communicator):
                 break
             if time.time() - t0 > self.serial_details['timeout']:
                 break
-            time.sleep(.01)
         return msg
 
     def loop(self):

--- a/src/regloicclib/Pump.py
+++ b/src/regloicclib/Pump.py
@@ -215,7 +215,7 @@ class Pump(object):
     def _time1(self, number, units='s'):
         """Convert number to 'time type 1'.
 
-        8 digits, 0 to 35964000 in units of 0.1s
+        1-8 digits, 0 to 35964000 in units of 0.1s
         (0 to 999 hr)
         """
         number = 10 * number  # 0.1s
@@ -224,6 +224,19 @@ class Pump(object):
         if units == 'h':
             number = 60 * number
         return str(min(number, 35964000)).encode()
+
+    def _time2(self, number, units='s'):
+        """Convert number to 'time type 2'.
+
+        8 digits, 0 to 35964000 in units of 0.1s, left-padded with zeroes
+        (0 to 999 hr)
+        """
+        number = 10 * number  # 0.1s
+        if units == 'm':
+            number = 60 * number
+        if units == 'h':
+            number = 60 * number
+        return str(min(number, 35964000)).zfill(8).encode()
 
     def _volume2(self, number):
         # convert number to "volume type 2"

--- a/src/regloicclib/Pump.py
+++ b/src/regloicclib/Pump.py
@@ -127,7 +127,7 @@ class Pump(object):
         # start
         self.hw.command(b'%dH' % channel)
 
-    def dispense_at_rate(self, vol, rate, units='ml/min', channel=None):
+    def dispense_vol_at_rate(self, vol, rate, units='ml/min', channel=None):
         """
         Dispense vol (ml) at rate on specified channel.
 
@@ -172,9 +172,9 @@ class Pump(object):
         # start
         self.hw.command(b'%dH' % channel)
 
-    def dispense_over_time(self, vol, time, channel=0):
+    def dispense_vol_over_time(self, vol, time, channel=0):
         """
-        Dispense vol (ml) over time (s) on specified channel.
+        Dispense vol (ml) over time (min) on specified channel.
 
         If no channel is specified, dispense on all channels.
         """
@@ -190,7 +190,34 @@ class Pump(object):
         # set volume
         self.hw.query(b'%dv%s' % (channel, self._volume2(vol)))
         # set time.  Note: if the time is too short, the pump will not start.
-        self.hw.query(b'%dxT%s' % (channel, self._time1(time)))
+        self.hw.query(b'%dxT%s' % (channel, self._time2(time, units='m')))
+        # make sure the running status gets set from the start to avoid later Sardana troubles
+        self.hw.setRunningStatus(True, channel)
+        # start
+        self.hw.command(b'%dH' % channel)
+
+    def dispense_flow_over_time(self, rate, time, units='ml/min', channel=0):
+        """
+        Dispense at a set flowrate over time (min) on specified channel.
+
+        Rate is specified by units, either 'ml/min' or 'rpm'.
+        If no channel is specified, dispense on all channels.
+        """
+        assert channel in self.channels or channel == 0
+        # set flow direction
+        if rate < 0:
+            self.hw.command(b'%dK' % channel)
+            rate *= -1
+        else:
+            self.hw.command(b'%dJ' % channel)
+        # set to flowrate mode first, otherwise Time mode uses RPMs
+        self.hw.query(b'%dM' % channel)
+        # Set to flowrate over time ("Time") mode
+        self.hw.command(b'%dN' % channel)
+        # set flowrate
+        self.hw.query(b'%df%s' % (channel, self._volume2(rate)))
+        # set time.  Note: if the time is too short, the pump will not start.
+        self.hw.query(b'%dxT%s' % (channel, self._time2(time, units='m')))
         # make sure the running status gets set from the start to avoid later Sardana troubles
         self.hw.setRunningStatus(True, channel)
         # start
@@ -223,7 +250,7 @@ class Pump(object):
             number = 60 * number
         if units == 'h':
             number = 60 * number
-        return str(min(number, 35964000)).encode()
+        return str(min(number, 35964000)).replace('.', '').encode()
 
     def _time2(self, number, units='s'):
         """Convert number to 'time type 2'.
@@ -236,7 +263,7 @@ class Pump(object):
             number = 60 * number
         if units == 'h':
             number = 60 * number
-        return str(min(number, 35964000)).zfill(8).encode()
+        return str(min(number, 35964000)).replace('.', '').zfill(8).encode()
 
     def _volume2(self, number):
         # convert number to "volume type 2"


### PR DESCRIPTION
Hello Alex,

Thanks again for publishing this.  It's been a while since https://github.com/alexbjorling/lib-maxiv-regloicc/pull/2 but I am working on this project again.

I wrote another new method to handle dispensing a set flowrate over time (which the manual calls "Time" mode).  It works for me (mostly) using an Ethernet <=> RS232 adapter; I've not tried with bare serial.

> Feel free to publish to PyPI! Not sure how that works, but as far as I'm concerned your fork is more active anyway so maybe use that.... but you might need to think of a more inspired name!

_Originally posted by @alexbjorling in https://github.com/alexbjorling/lib-maxiv-regloicc/issues/2#issuecomment-1235189001_


At this point my company has a real use case, so I can hopefully deploy the code and start getting some real user testing.  (To date it's just been me on a bench).   I'm going to move my fork to the ['NuMat' organization](https://github.com/numat), rename it (probably to the pump brand `ismatec`, and publish to PyPI.  I'm happy to keep sending PR's your way but expect the refactors will get more intense.

Do you know if there are any other users of your code besides me?  The Hein Group has apparently re-implemented from scratch on [GitLab](https://gitlab.com/heingroup/ismatec/-/tree/master/ismatec).  @patrickfuller and I have reached out to them (on another project) a few times, and they were unresponsive.  Still, their code has a couple useful ideas.